### PR TITLE
fix: missing translation

### DIFF
--- a/data/blog/git-switch-y-git-restore.mdx
+++ b/data/blog/git-switch-y-git-restore.mdx
@@ -75,7 +75,7 @@ Otra diferencia es que con `git checkout` puedes crear y cambiar a la nueva rama
 git checkout -b new-branch
 ```
 
-You can do the same with the new one, but the flag is `-c`:
+Puedes hacer lo mismo con el nuevo, pero la bandera es `-c`:
 
 ```shell
 git switch -c new-branch


### PR DESCRIPTION
Before: 
You can do the same with the new one, but the flag is `-c`:

After:
Puedes hacer lo mismo con el nuevo, pero la bandera es `-c`: